### PR TITLE
Update CMakeLists.txt to include(FetchContent)

### DIFF
--- a/onnxruntime_cpp_samples/cuda_provider/CMakeLists.txt
+++ b/onnxruntime_cpp_samples/cuda_provider/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(cuda_sample PRIVATE
 
 # https://github.com/microsoft/onnxruntime/issues/11236
 if (WIN32)
+    include(FetchContent)
     FetchContent_Declare(zlib_dll
             URL http://www.winimage.com/zLibDll/zlib123dllx64.zip)
     FetchContent_MakeAvailable(zlib_dll)


### PR DESCRIPTION
### Description 

The `cuda_provider/CMakeLists.txt` is missing an `include(FetchContent)` if configuring the CMakeList for `WIN32`